### PR TITLE
Added new script mjt_clone_config

### DIFF
--- a/maasjuju_toolkit/maas/clone_config.py
+++ b/maasjuju_toolkit/maas/clone_config.py
@@ -29,9 +29,6 @@ $ mjt_clone_config --source SOURCE --dest DEST --storage --interfaces [--force]
 """
 
 import argparse
-import logging
-
-# logging.basicConfig(level=logging.DEBUG)
 
 from maasjuju_toolkit.util import (
     query_machines, exit_with_error, session, MaaSError)
@@ -64,14 +61,12 @@ def clone_config(args):
             exit_with_error('[ERROR] Aborted!')
 
     try:
-        result = session().Machines.clone(
-            # source=source.system_id,
-            # destination=[x.system_id for x in destinations],
+        session().Machines.clone(
+            source=source.system_id,
+            destinations=[x.system_id for x in destinations],
             interfaces=args.interfaces,
             storage=args.storage
         )
-
-        print(result)
 
     except MaaSError as e:
         exit_with_error(f'[ERROR] MaaS: {e}')
@@ -94,7 +89,7 @@ def main():
     parser.add_argument('--force', action='store_true', default=False,
                         help='Do not ask for confirmation')
 
-    clone_config(args = parser.parse_args())
+    clone_config(args=parser.parse_args())
 
 
 if __name__ == '__main__':

--- a/maasjuju_toolkit/maas/clone_config.py
+++ b/maasjuju_toolkit/maas/clone_config.py
@@ -19,7 +19,8 @@ Last Update: 2019/11/08
 Description: Clone storage and/or interface configuration between machines
 
 # Usage:
-$ mjt_clone_config --source SOURCE --dest DEST --storage --interfaces [--force]
+$ mjt_clone_config --source SOURCE --storage --interfaces [--force] \
+    --destinations DEST_1 [DEST_2 ...]
 
 # Notes:
 * Machines can be matched using system id, hostname, domain name or tags.
@@ -43,7 +44,7 @@ def clone_config(args):
     elif not sources:
         exit_with_error('[ERROR] No source machine!')
 
-    destinations = query_machines(args.dest)
+    destinations = query_machines(args.destinations)
     if not destinations:
         exit_with_error('[ERROR] No destination machines!')
 
@@ -76,11 +77,11 @@ def main():
     """parses arguments and does work"""
 
     parser = argparse.ArgumentParser(
-        description='Αdd tags to many MaaS machines'
-    )
+        description='Clone MaaS machines configuration')
+
     parser.add_argument('--source', type=str, required=True,
                         help='Source machine')
-    parser.add_argument('--dest', type=str, required=True,
+    parser.add_argument('--destinations', type=str, required=True, nargs='+',
                         help='Destination machines')
     parser.add_argument('--interfaces', action='store_true', default=False,
                         help='Clone network interfaces configuration')

--- a/maasjuju_toolkit/maas/clone_config.py
+++ b/maasjuju_toolkit/maas/clone_config.py
@@ -69,7 +69,7 @@ def clone_config(args):
         )
 
     except MaaSError as e:
-        exit_with_error('[ERROR] MaaS: {}'.format(e))
+        exit_with_error('[ERROR] MaaS: {} {}'.format(e.status, e.content))
 
 
 def main():

--- a/maasjuju_toolkit/maas/clone_config.py
+++ b/maasjuju_toolkit/maas/clone_config.py
@@ -69,7 +69,7 @@ def clone_config(args):
         )
 
     except MaaSError as e:
-        exit_with_error(f'[ERROR] MaaS: {e}')
+        exit_with_error('[ERROR] MaaS: {}'.format(e))
 
 
 def main():

--- a/maasjuju_toolkit/maas/clone_config.py
+++ b/maasjuju_toolkit/maas/clone_config.py
@@ -1,0 +1,101 @@
+# Copyright (C) 2019  GRNET S.A.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""
+Author: Aggelos Kolaitis <akolaitis@admin.grnet.gr>
+Last Update: 2019/11/08
+Description: Clone storage and/or interface configuration between machines
+
+# Usage:
+$ mjt_clone_config --source SOURCE --dest DEST --storage --interfaces [--force]
+
+# Notes:
+* Machines can be matched using system id, hostname, domain name or tags.
+  See `utils.py:query_machines()` for details.
+* This may be a destructive operation. The scripts asks for confirmation by
+  default, but accepts a '--force' flag.
+"""
+
+import argparse
+import logging
+
+# logging.basicConfig(level=logging.DEBUG)
+
+from maasjuju_toolkit.util import (
+    query_machines, exit_with_error, session, MaaSError)
+
+
+def clone_config(args):
+    """Clones MaaS machines configuration"""
+    sources = query_machines(args.source)
+    if len(sources) > 1:
+        exit_with_error('[ERROR] More than one source machines!: {}'.format(
+            list(x.hostname for x in sources)))
+    elif not sources:
+        exit_with_error('[ERROR] No source machine!')
+
+    destinations = query_machines(args.dest)
+    if not destinations:
+        exit_with_error('[ERROR] No destination machines!')
+
+    source = sources[0]
+
+    print('Will clone configuration from {} ({}) to:'.format(
+        source.system_id, source.hostname
+    ))
+    for dest in destinations:
+        print('* {} ({})'.format(dest.system_id, dest.hostname))
+
+    if not args.force:
+        re = input('Are you sure [y/N]? ')
+        if re.lower() != 'y':
+            exit_with_error('[ERROR] Aborted!')
+
+    try:
+        result = session().Machines.clone(
+            # source=source.system_id,
+            # destination=[x.system_id for x in destinations],
+            interfaces=args.interfaces,
+            storage=args.storage
+        )
+
+        print(result)
+
+    except MaaSError as e:
+        exit_with_error(f'[ERROR] MaaS: {e}')
+
+
+def main():
+    """parses arguments and does work"""
+
+    parser = argparse.ArgumentParser(
+        description='Αdd tags to many MaaS machines'
+    )
+    parser.add_argument('--source', type=str, required=True,
+                        help='Source machine')
+    parser.add_argument('--dest', type=str, required=True,
+                        help='Destination machines')
+    parser.add_argument('--interfaces', action='store_true', default=False,
+                        help='Clone network interfaces configuration')
+    parser.add_argument('--storage', action='store_true', default=False,
+                        help='Clone storage configuration')
+    parser.add_argument('--force', action='store_true', default=False,
+                        help='Do not ask for confirmation')
+
+    clone_config(args = parser.parse_args())
+
+
+if __name__ == '__main__':
+    main()

--- a/maasjuju_toolkit/util.py
+++ b/maasjuju_toolkit/util.py
@@ -123,8 +123,8 @@ def query_machines(machine_filters):
     See examples in EXAMPLES.md"""
     rows = MaaSCache.select().order_by(MaaSCache.fqdn)
 
-    if isinstance(machine_filters, str):
-        machine_filters = [machine_filters]
+    if not isinstance(machine_filters, list):
+        exit_with_error('Programming error: query_machines() requires a list')
 
     if machine_filters:
         # search fqdn, system id

--- a/maasjuju_toolkit/util.py
+++ b/maasjuju_toolkit/util.py
@@ -123,6 +123,9 @@ def query_machines(machine_filters):
     See examples in EXAMPLES.md"""
     rows = MaaSCache.select().order_by(MaaSCache.fqdn)
 
+    if isinstance(machine_filters, str):
+        machine_filters = [machine_filters]
+
     if machine_filters:
         # search fqdn, system id
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ console_scripts =
     mjt_script_results = maasjuju_toolkit.maas.script_results:main
 
     mjt_add_tags = maasjuju_toolkit.maas.add_tags:main
+    mjt_clone_config = maasjuju_toolkit.maas.clone_config:main
 
     mjt_get_ipmi_info = maasjuju_toolkit.maas.get_ipmi_info:main
     mjt_get_machine = maasjuju_toolkit.maas.get_machine:main


### PR DESCRIPTION
Added script mjt_clone_config, which can be used to clone machine configuration (for storage and network interfaces) from one Maas machine to another.